### PR TITLE
Add Dependabot config for bundler ecosystem

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+version: 2
+updates:
+  - package-ecosystem: "bundler"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      bundler-dependencies:
+        patterns:
+          - "*"
+    open-pull-requests-limit: 10


### PR DESCRIPTION
## Summary
- Adds `.github/dependabot.yml` covering the bundler ecosystem (the only package ecosystem in this repo)
- Configures weekly schedule with grouped updates to reduce PR noise
- No pip/npm/GitHub Actions ecosystems detected; bundler-only coverage is complete

## Audit findings
- **Missing config:** No `.github/dependabot.yml` existed
- **Ecosystem coverage:** Bundler (Gemfile/Gemfile.lock) -- now covered
- **Schedule:** Weekly
- **Grouped updates:** All bundler deps grouped into a single PR
- **Note:** GitHub flagged 1 moderate vulnerability on the default branch

## Test plan
- [ ] Verify Dependabot starts creating PRs after merge
- [ ] Confirm grouped bundler updates appear as single PRs

Generated with [Claude Code](https://claude.com/claude-code)